### PR TITLE
Accounting year with default numeric value

### DIFF
--- a/pyVerein/finance/dynamic_preferences_registry.py
+++ b/pyVerein/finance/dynamic_preferences_registry.py
@@ -27,5 +27,5 @@ class Currency(StringPreference):
 class AccountingYear(StringPreference):
     section = finance
     name = 'accounting_year'
-    default = ''
+    default = '2021'
     verbose_name = "Acounting year"


### PR DESCRIPTION
First time login fails with `ValueError: invalid literal for int() with base 10: ''`
Python 3 expects a value to parse and throws the above-mentioned error otherwise.

I fixed the problem by entering default value directly in the database, but this could be caught during installation.